### PR TITLE
fix a few broken responses

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,5 @@
+docker run --rm \
+  -v "${PWD}":/local openapitools/openapi-generator-cli generate \
+  -i /local/u2plus-open-api-spec.yaml \
+  -g html \
+  -o /local/out/html

--- a/u2plus-open-api-spec.yaml
+++ b/u2plus-open-api-spec.yaml
@@ -2475,6 +2475,8 @@ paths:
                 properties:
                   errors:
                     type: array
+                    items:
+                      type: string
               examples:
                 "Require parameter tracks":
                   value: |-
@@ -2490,6 +2492,8 @@ paths:
                 properties:
                   errors:
                     type: array
+                    items:
+                      type: string
               examples:
                 FILE DOESN'T EXIST:
                   value: |-
@@ -2880,6 +2884,8 @@ paths:
                 properties:
                   errors:
                     type: array
+                    items:
+                      type: string
               examples:
                 "Requires parameter tracks":
                   value: |-

--- a/u2plus-open-api-spec.yaml
+++ b/u2plus-open-api-spec.yaml
@@ -186,7 +186,7 @@ paths:
           name: length
           required: false
           schema:
-            type: string
+            type: integer
             default: 256
             minimum: 0
             example: 128
@@ -2826,7 +2826,7 @@ paths:
           name: tracks
           required: true
           schema:
-            type: string
+            type: integer
             minimum: 1
             maximum: 255
           example: "255"


### PR DESCRIPTION
Running the openapi-generator found a few errors and warnings. I've added a script that runs the generator, if you don't want that in the repo I can remove it.