### PR TITLE
reuse errors field

### DIFF
--- a/u2plus-open-api-spec.yaml
+++ b/u2plus-open-api-spec.yaml
@@ -825,7 +825,7 @@ paths:
                 Undefined subsystem command:
                   value: |-
                     {
-                      "errors" : [ "Undefined subsystem command" ]
+                      "errors" : [ "Undefined subsystem command" ]x
                     }
         '507':
           description: Unknown
@@ -2377,51 +2377,6 @@ paths:
                       "bytes_written": 196608,
                       "errors": []
                     }
-#        '400':
-#          description: "Bad request"
-#          content:
-#            application/json:
-#              schema:
-#                type: object
-#                properties:
-#                  errors:
-#                    type: array
-#              examples:
-#                "Require parameter tracks":
-#                  value: |-
-#                    {
-#                      "errors" : [ "Function create_d64 requires parameter tracks" ]
-#                    }
-#        409:
-#          description: Conflict
-#          content:
-#            application/json:
-#              schema:
-#                type: object
-#                properties:
-#                  status:
-#                    type: string
-#                  error:
-#                    type: string
-#                  path:
-#                    type: string
-#                  tracks:
-#                    type: integer
-#                  diskname:
-#                    type: string
-#                  message:
-#                    type: string
-#              examples:
-#                "File exists":
-#                  value: |-
-#                    {
-#                      "status": 409,
-#                      "error": "Conflict",
-#                      "path" : "/Temp/diskimage.dnp",
-#                      "tracks" : 255,
-#                      "diskname" : "-= scs+trc 2024 =-",
-#                      "message" : "A file with the same name already exists. Please choose a different name."
-#                    }
         '500':
           description: "Error: Internal Server Error"
           content:
@@ -2488,21 +2443,6 @@ paths:
                       "bytes_written": 349696,
                       "errors": []
                     }
-#        '400':
-#          description: "Bad request"
-#          content:
-#            application/json:
-#              schema:
-#                type: object
-#                properties:
-#                  errors:
-#                    type: array
-#              examples:
-#                "Require parameter tracks":
-#                  value: |-
-#                    {
-#                      "errors" : [ "Function create_d71 requires parameter tracks" ]
-#                    }
         '500':
           description: "Error: Internal Server Error"
           content:
@@ -2669,36 +2609,6 @@ paths:
                     {
                       "errors" : [ "Function create_dnp requires parameter tracks" ]
                     }
-#        409:
-#          description: Conflict
-#          content:
-#            application/json:
-#              schema:
-#                type: object
-#                properties:
-#                  status:
-#                    type: string
-#                  error:
-#                    type: string
-#                  path:
-#                    type: string
-#                  tracks:
-#                    type: integer
-#                  diskname:
-#                    type: string
-#                  message:
-#                    type: string
-#              examples:
-#                "File exists":
-#                  value: |-
-#                    {
-#                      "status": 409,
-#                      "error": "Conflict",
-#                      "path" : "/Temp/diskimage.dnp",
-#                      "tracks" : 255,
-#                      "diskname" : "-= scs+trc 2024 =-",
-#                      "message" : "A file with the same name already exists. Please choose a different name."
-#                    }
         '500':
           description: "Error: Internal Server Error"
           content:

--- a/u2plus-open-api-spec.yaml
+++ b/u2plus-open-api-spec.yaml
@@ -36,14 +36,12 @@ paths:
                       "errors": [ ]
                     }
               schema:
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
                 type: object
                 properties:
                   version:
                     type: string
-                  errors:
-                    type: array
-                    items:
-                      type: string
         '404':
           description: Not Found
         '504':
@@ -61,12 +59,8 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
   /machine:reboot:
@@ -82,12 +76,8 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
   /machine:pause:
@@ -105,12 +95,8 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
   /machine:resume:
@@ -126,12 +112,8 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
           content:
@@ -151,12 +133,8 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
   /machine:readmem:
@@ -216,12 +194,8 @@ paths:
                       "errors" : [ "Memory read exceeds location $FFFF" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
   /machine:writemem:
@@ -271,12 +245,8 @@ paths:
                       "errors": [ ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad request
           content:
@@ -293,12 +263,8 @@ paths:
                       "errors" : [ "Maximum length of 128 bytes exceeded. Consider using POST method with attachment." ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
     post:
@@ -337,12 +303,8 @@ paths:
                       "errors": [ ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad request
           content:
@@ -359,12 +321,8 @@ paths:
                       "errors" : [ "Maximum length of 128 bytes exceeded. Consider using POST method with attachment." ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
   /machine:debugreg:
@@ -389,12 +347,8 @@ paths:
                       "errors": []
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
     put:
@@ -428,12 +382,8 @@ paths:
                       "errors": []
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
   /runners:sidplay:
@@ -479,12 +429,8 @@ paths:
                       "errors" : [ "Function sidplay does not have parameter invalidParameterName", "Function sidplay requires parameter file" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
         '500':
@@ -535,12 +481,8 @@ paths:
                       "errors" : [ "Function sidplay does not have parameter invalidParameterName", "Function sidplay requires parameter file" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
         '500':
@@ -597,12 +539,8 @@ paths:
                       "errors" : [ "Function modplay does not have parameter invalidParameterName", "Function modplay requires parameter file" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
         '500':
@@ -654,12 +592,8 @@ paths:
                     requires parameter file" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
         '500':
@@ -717,12 +651,8 @@ paths:
                       "errors" : [ "Function loadprg does not have parameter invalidParameterName", "Function loadprg requires parameter file" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
         '500':
@@ -775,12 +705,8 @@ paths:
                     requires parameter file" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
         '500':
@@ -834,12 +760,8 @@ paths:
                     requires parameter file" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
         '500':
@@ -880,12 +802,8 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
               examples:
                 OK:
                   value: |-
@@ -954,12 +872,8 @@ paths:
                       "errors" : [ "Function run_crt requires parameter file" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
         '500':
@@ -1012,12 +926,8 @@ paths:
                     requires parameter file" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
         '500':
@@ -1179,12 +1089,8 @@ paths:
                       "errors" : [ "Function loadprg does not have parameter invalidParameterName Function run_crt, requires parameter file" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad Request
           content:
@@ -1288,12 +1194,8 @@ paths:
                       "errors" : [ "Function mount does not have parameter invalidParameterName", "Function mount requires parameter file" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad Request
           content:
@@ -1361,12 +1263,8 @@ paths:
                       "errors": []
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad Request
           content:
@@ -1378,12 +1276,8 @@ paths:
                       "errors": [ "Invalid Drive 'c'" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
   /drives/{drive}:remove:
     put:
       operationId: putRemoveDisk
@@ -1414,12 +1308,8 @@ paths:
                       "errors": []
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad Request
           content:
@@ -1431,12 +1321,8 @@ paths:
                       "errors": [ "Invalid Drive 'c'" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
   /drives/{drive}:unlink:
     put:
       operationId: putUnlinkDisk
@@ -1468,12 +1354,8 @@ paths:
                       "errors": []
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad Request
           content:
@@ -1485,12 +1367,8 @@ paths:
                       "errors": [ "Invalid Drive 'c'" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
   /drives/{drive}:on:
     put:
       operationId: putUnEnableDrive
@@ -1521,12 +1399,8 @@ paths:
                       "errors": []
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad Request
           content:
@@ -1538,12 +1412,8 @@ paths:
                       "errors": [ "Invalid Drive 'c'" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
   /drives/{drive}:off:
     put:
       operationId: putDisableDrive
@@ -1575,12 +1445,8 @@ paths:
                       "errors": []
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad Request
           content:
@@ -1592,12 +1458,8 @@ paths:
                       "errors": [ "Invalid Drive 'c'" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
   /drives/{drive}:load_rom:
     put:
       operationId: putLoadDriveRom
@@ -1642,12 +1504,8 @@ paths:
                       "errors": []
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad Request
           content:
@@ -1659,12 +1517,8 @@ paths:
                       "errors": [ "Invalid Drive 'c'" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
     post:
       operationId: postLoadRom
       summary: Load disk drive rom
@@ -1704,12 +1558,8 @@ paths:
                       "errors": []
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad Request
           content:
@@ -1721,12 +1571,8 @@ paths:
                       "errors": [ "Invalid Drive 'c'" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
   /drives/{drive}:set_mode:
     put:
       operationId: postSetMode
@@ -1769,12 +1615,8 @@ paths:
                       "errors": []
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad Request
           content:
@@ -1786,12 +1628,8 @@ paths:
                       "errors": [ "Invalid Drive 'c'" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
   /streams/{streamname}:start:
     put:
       operationId: putStartDataStream
@@ -1841,12 +1679,8 @@ paths:
                       "errors": []
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad Request
           content:
@@ -1867,12 +1701,8 @@ paths:
                       ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '404':
           description: Not Found
           content:
@@ -1889,12 +1719,8 @@ paths:
                       "errors": [ "Unrecognized stream name 'vdeo'" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
   /streams/{streamname}:stop:
     put:
       operationId: putStopDataStream
@@ -1926,12 +1752,8 @@ paths:
                       "errors": []
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad Request
           content:
@@ -2018,13 +1840,11 @@ paths:
                         "errors": []
                       }
               schema:
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
                 type: object
                 properties:
                   categories:
-                    type: array
-                    items:
-                      type: string
-                  errors:
                     type: array
                     items:
                       type: string
@@ -2171,13 +1991,11 @@ paths:
                       "errors": []
                     }
               schema:
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
                 type: object
                 properties:
                   categories:
-                    type: array
-                    items:
-                      type: string
-                  errors:
                     type: array
                     items:
                       type: string
@@ -2260,13 +2078,11 @@ paths:
                       "errors": []
                     }
               schema:
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
                 type: object
                 properties:
                   categories:
-                    type: array
-                    items:
-                      type: string
-                  errors:
                     type: array
                     items:
                       type: string
@@ -2337,12 +2153,8 @@ paths:
                       "errors": []
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
         '400':
           description: Bad Request
           content:
@@ -2354,12 +2166,8 @@ paths:
                       "errors": [ "Invalid Drive 'c'" ]
                     }
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
   /configs:load_from_flash:
     put:
       operationId: PutConfigFromFlash
@@ -2418,12 +2226,8 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
               examples:
                 'File information - d64':
                   value: |-
@@ -2474,12 +2278,8 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
               examples:
                 "Require parameter tracks":
                   value: |-
@@ -2491,12 +2291,8 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
               examples:
                 FILE DOESN'T EXIST:
                   value: |-
@@ -2546,6 +2342,8 @@ paths:
           content:
             application/json:
               schema:
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
                 type: object
                 properties:
                   path:
@@ -2560,10 +2358,6 @@ paths:
                     example: "-= scs+trc 2024 =-"
                   bytes_written:
                     type: integer
-                  errors:
-                    type: array
-                    items:
-                      type: string
               examples:
                 "Successful operation D64 - 35 tracks":
                   value: |-
@@ -2633,14 +2427,12 @@ paths:
           content:
             application/json:
               schema:
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
                 type: object
                 properties:
                   version:
                     type: string
-                  errors:
-                    type: array
-                    items:
-                      type: string
               examples:
                 "File exists":
                   value: |-
@@ -2684,12 +2476,8 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
               examples:
                 'Successful operation':
                   value: |-
@@ -2720,14 +2508,12 @@ paths:
           content:
             application/json:
               schema:
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
                 type: object
                 properties:
                   version:
                     type: string
-                  errors:
-                    type: array
-                    items:
-                      type: string
               examples:
                 "File exists":
                   value: |-
@@ -2769,12 +2555,8 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
               examples:
                 'Successful operation':
                   value: |-
@@ -2789,14 +2571,12 @@ paths:
           content:
             application/json:
               schema:
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
                 type: object
                 properties:
                   version:
                     type: string
-                  errors:
-                    type: array
-                    items:
-                      type: string
               examples:
                 "File exists":
                   value: |-
@@ -2849,6 +2629,8 @@ paths:
           content:
             application/json:
               schema:
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
                 type: object
                 properties:
                   path:
@@ -2864,10 +2646,6 @@ paths:
                     example: "scs+trc 2024"
                   bytes_written:
                     type: integer
-                  errors:
-                    type: array
-                    items:
-                      type: string
               examples:
                 "Successful operation":
                   value: |-
@@ -2883,12 +2661,8 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
               examples:
                 "Requires parameter tracks":
                   value: |-
@@ -2930,14 +2704,12 @@ paths:
           content:
             application/json:
               schema:
+                allOf:
+                  - $ref: '#/components/schemas/Errors'
                 type: object
                 properties:
                   version:
                     type: string
-                  errors:
-                    type: array
-                    items:
-                      type: string
               examples:
                 "File exists":
                   value: |-
@@ -2949,3 +2721,14 @@ paths:
                         "FILE EXISTS"
                       ]
                     }
+
+components:
+  schemas:
+    Errors:
+      type: object
+      required: [ errors ]
+      properties:
+        errors:
+          type: array
+          items:
+            type: string


### PR DESCRIPTION
The "errors" field was begging to be reused, so I did that.
Note that I made it required. I haven't seen a request that doesn't return the errors field, but Gideon is a bit vague about it.

Please check carefully if I haven't made any copy-paste mistakes!